### PR TITLE
ULIDのデータベース型をchar(26)→binary(16)へ

### DIFF
--- a/server/repository/dialogue.go
+++ b/server/repository/dialogue.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Dialogue struct {
-	ID       ulid.ULID `gorm:"primaryKey;type:char(26);not null"`
-	PageID   ulid.ULID `gorm:"type:char(26);not null"`
+	ID       ulid.ULID `gorm:"primaryKey;type:binary(16);not null"`
+	PageID   ulid.ULID `gorm:"type:binary(16);not null"`
 	Dialogue string    `gorm:"type:text;not null"`
 	Top      float64   `gorm:"type:float;not null"`
 	Bottom   float64   `gorm:"type:float;not null"`

--- a/server/repository/line.go
+++ b/server/repository/line.go
@@ -34,8 +34,8 @@ func (p Point) Value() (driver.Value, error) {
 }
 
 type Line struct {
-	ID      ulid.ULID `gorm:"primaryKey;type:char(26);not null"`
-	PageID  ulid.ULID `gorm:"type:char(26);not null"`
+	ID      ulid.ULID `gorm:"primaryKey;type:binary(16);not null"`
+	PageID  ulid.ULID `gorm:"type:binary(16);not null"`
 	PenSize int       `gorm:"type:int;not null"`
 	Points  []Point   `gorm:"type:text;not null"`
 	Page    Page      `gorm:"foreignKey:PageID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`

--- a/server/repository/page.go
+++ b/server/repository/page.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Page struct {
-	ID        ulid.ULID `gorm:"type:char(26);not null;primaryKey"`
-	ProjectID ulid.ULID `gorm:"type:char(26);not null"`
+	ID        ulid.ULID `gorm:"type:binary(16);not null;primaryKey"`
+	ProjectID ulid.ULID `gorm:"type:binary(16);not null"`
 	Index     int       `gorm:"type:int;not null"`
 	Height    int       `gorm:"type:int;not null"`
 	Width     int       `gorm:"type:int;not null"`

--- a/server/repository/project.go
+++ b/server/repository/project.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Project struct {
-	ID        ulid.ULID `gorm:"type:char(26);not null;primaryKey"`
+	ID        ulid.ULID `gorm:"type:binary(16);not null;primaryKey"`
 	Name      string    `gorm:"type:varchar(255);not null"`
 	Thumbnail string    `gorm:"type:varchar(255);not null"`
 	CreatedAt time.Time `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP"`


### PR DESCRIPTION
ここを読む感じデフォではバイナリ配列としてデータベースに記録してるっぽいので
https://github.com/oklog/ulid/blob/main/ulid.go#L532