### PR TITLE
オリジナルULIDパッケージを使用

### DIFF
--- a/server/repository/dialogue.go
+++ b/server/repository/dialogue.go
@@ -3,7 +3,7 @@ package repository
 import (
 	"context"
 
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 )
 
 type Dialogue struct {

--- a/server/repository/dialogue.go
+++ b/server/repository/dialogue.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Dialogue struct {
-	ID       ulid.ULID `gorm:"type:binary(16);not null;primaryKey"`
-	PageID   ulid.ULID `gorm:"type:binary(16);not null"`
+	ID       ulid.ULID `gorm:"type:char(26);not null;primaryKey"`
+	PageID   ulid.ULID `gorm:"type:char(26);not null"`
 	Dialogue string    `gorm:"type:text;not null"`
 	Top      float64   `gorm:"type:float;not null"`
 	Bottom   float64   `gorm:"type:float;not null"`

--- a/server/repository/gorm2/dialogue.go
+++ b/server/repository/gorm2/dialogue.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 	"gorm.io/gorm"
 )
 
@@ -77,10 +77,10 @@ func (repo *Repository) UpdateDialogue(
 
 	err = tx.Model(&repository.Dialogue{}).Where("id = ?", id).Updates(repository.Dialogue{
 		Dialogue: dialogue,
-		Top: top,
-		Bottom: bottom,
-		Left: left,
-		Right: right,
+		Top:      top,
+		Bottom:   bottom,
+		Left:     left,
+		Right:    right,
 	}).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/server/repository/gorm2/line.go
+++ b/server/repository/gorm2/line.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 	"gorm.io/gorm"
 )
 

--- a/server/repository/gorm2/page.go
+++ b/server/repository/gorm2/page.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 	"gorm.io/gorm"
 )
 

--- a/server/repository/gorm2/project.go
+++ b/server/repository/gorm2/project.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 	"gorm.io/gorm"
 )
 

--- a/server/repository/line.go
+++ b/server/repository/line.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 )
 
 type Point struct {

--- a/server/repository/line.go
+++ b/server/repository/line.go
@@ -40,8 +40,8 @@ func (p Points) Value() (driver.Value, error) {
 }
 
 type Line struct {
-	ID      ulid.ULID `gorm:"type:binary(16);not null;primaryKey"`
-	PageID  ulid.ULID `gorm:"type:binary(16);not null"`
+	ID      ulid.ULID `gorm:"type:char(26);not null;primaryKey"`
+	PageID  ulid.ULID `gorm:"type:char(26);not null"`
 	PenSize int       `gorm:"type:int;not null"`
 	Points  Points    `gorm:"type:text;not null"`
 	Page    Page      `gorm:"foreignKey:PageID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`

--- a/server/repository/page.go
+++ b/server/repository/page.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Page struct {
-	ID        ulid.ULID `gorm:"type:binary(16);not null;primaryKey"`
-	ProjectID ulid.ULID `gorm:"type:binary(16);not null"`
+	ID        ulid.ULID `gorm:"type:char(26);not null;primaryKey"`
+	ProjectID ulid.ULID `gorm:"type:char(26);not null"`
 	Index     int       `gorm:"type:int;not null"`
 	Height    int       `gorm:"type:int;not null"`
 	Width     int       `gorm:"type:int;not null"`

--- a/server/repository/page.go
+++ b/server/repository/page.go
@@ -3,7 +3,7 @@ package repository
 import (
 	"context"
 
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 )
 
 type Page struct {

--- a/server/repository/project.go
+++ b/server/repository/project.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Project struct {
-	ID        ulid.ULID `gorm:"type:binary(16);not null;primaryKey"`
+	ID        ulid.ULID `gorm:"type:char(26);not null;primaryKey"`
 	Name      string    `gorm:"type:varchar(255);not null"`
 	Thumbnail string    `gorm:"type:varchar(255);not null"`
 	CreatedAt time.Time `gorm:"type:DATETIME;not null;default:CURRENT_TIMESTAMP"`

--- a/server/repository/project.go
+++ b/server/repository/project.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 )
 
 type Project struct {

--- a/server/router/content/content.go
+++ b/server/router/content/content.go
@@ -2,7 +2,7 @@ package content
 
 import (
 	"github.com/digicon-hack-07/ez-toon/server/repository"
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 )
 
 type Point struct {

--- a/server/router/content/handler.go
+++ b/server/router/content/handler.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 	"github.com/labstack/echo/v4"
-	"github.com/oklog/ulid/v2"
 )
 
 type PostLineRequest struct {

--- a/server/router/page/handler.go
+++ b/server/router/page/handler.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 	"github.com/labstack/echo/v4"
-	"github.com/oklog/ulid/v2"
 )
 
 type PostPageRequest struct {

--- a/server/router/page/page.go
+++ b/server/router/page/page.go
@@ -2,7 +2,7 @@ package page
 
 import (
 	"github.com/digicon-hack-07/ez-toon/server/repository"
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 )
 
 type Page struct {

--- a/server/router/project/handler.go
+++ b/server/router/project/handler.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 	"github.com/labstack/echo/v4"
-	"github.com/oklog/ulid/v2"
 )
 
 type GetProjectsResponse []Project

--- a/server/router/project/project.go
+++ b/server/router/project/project.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/digicon-hack-07/ez-toon/server/repository"
-	"github.com/oklog/ulid/v2"
+	"github.com/digicon-hack-07/ez-toon/server/utils/ulid"
 )
 
 type Project struct {

--- a/server/utils/ulid/ulid.go
+++ b/server/utils/ulid/ulid.go
@@ -1,0 +1,43 @@
+package ulid
+
+import (
+	"database/sql/driver"
+
+	"github.com/oklog/ulid/v2"
+)
+
+type ULID struct {
+	ulid.ULID
+}
+
+func Make() ULID {
+	id := ulid.Make()
+
+	return ULID{id}
+}
+
+func Parse(value string) (ULID, error) {
+	id, err := ulid.Parse(value)
+	if err != nil {
+		return ULID{}, err
+	}
+
+	return ULID{id}, nil
+}
+
+func (id *ULID) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return id.UnmarshalText([]byte(v))
+	case []byte:
+		return id.UnmarshalText(v)
+	}
+
+	return ulid.ErrScanValue
+}
+
+func (id ULID) Value() (driver.Value, error) {
+	return id.String(), nil
+}


### PR DESCRIPTION
本家ULIDパッケージは`Scan()`と`Value()`時に`[]byte`との相互変換を基本としている
これでは非常に扱いにくいので、`string`との変換をするよう、該当の関数だけオーバーライドした