### PR TITLE
消しゴムの判定挙動の改善

### DIFF
--- a/client/src/lib/edittools/EraserToolHandler.ts
+++ b/client/src/lib/edittools/EraserToolHandler.ts
@@ -23,6 +23,15 @@ function lineIntersect(
   const q = (l2ax - l2bx) * (l1by - l2ay) - (l2ay - l2by) * (l1bx - l2ax)
   if (p * q > 0) return false
 
+  if (s == t || p == q)
+    // s = t = 0, p = q = 0
+    return (
+      Math.min(l1ax, l1bx) <= Math.max(l2ax, l2bx) &&
+      Math.min(l2ax, l2bx) <= Math.max(l1ax, l1bx) &&
+      Math.min(l1ay, l1by) <= Math.max(l2ay, l2by) &&
+      Math.min(l2ay, l2by) <= Math.max(l1ay, l1by)
+    )
+
   return true
 }
 


### PR DESCRIPTION
元々この記事を元にした判定処理をしていた
https://qiita.com/zu_rin/items/e04fdec4e3dec6072104

4点が一直線上となる場合の処理が抜けており、交差していないのに交差している判定になることがあったので改善
XY軸それぞれについて一次元上の重なりの判定を行った
https://koseki.hatenablog.com/entry/20111021/range